### PR TITLE
bs4 implementation 

### DIFF
--- a/dataset/datasetGen.py
+++ b/dataset/datasetGen.py
@@ -48,7 +48,7 @@ class DataSetGen:
         self.soup = BeautifulSoup(str(content), 'html.parser')
 
         question = self.get_question()
-        source_verified = self.is_verified()
+        source_verified, url = self.is_verified()
         manual_verified = False
         if not source_verified:  # skip over ones without accepted answers
             return None
@@ -96,7 +96,10 @@ class DataSetGen:
         for tag in self.tag_urls:
             _urls = self.tag_urls[tag]
             for url in _urls:
-                _dataset.append(self.url_to_data(url=url))
+                data = self.url_to_data(url=url)
+                if data is None:
+                    continue
+                _dataset.append()
             print(f"Collected data from {len(_urls)} urls with tag {tag}")
         return _dataset
 

--- a/dataset/datasetGen.py
+++ b/dataset/datasetGen.py
@@ -14,39 +14,47 @@ def Tag_To_Url(base: str, tag: str, page: int):
     yield tag_url
 
 
-def Link_To_Data(urls: list):
-    url = urls[0] #test
+def Url_To_Data(url: str):
     platform = search('https?://([A-Za-z_0-9.-]+).com*', url).group(1)
-    print(f"Platform: {platform}")
     with request.urlopen(url) as response:
         content = response.read()
     soup = BeautifulSoup(str(content), 'html.parser')
-    question = soup.find("a", {"class": "question-hyperlink"})
-    print(f"Question: {question.text}") #title of the question
+    question = soup.find("a", {"class": "question-hyperlink"}).text
 
     source_verified = False
     verified_question = soup.find("div", {"class": "answer accepted-answer"})
     if verified_question:
         source_verified = True #is an accepted answer
-    print(f"Source_Verified: {source_verified}")
 
     manual_verified = False
-    print(f"Manual_Verified: {manual_verified}") #to be done later
 
     answer = soup.find("div", {"class": "answercell post-layout--right"})
     code_blocks = answer.find_all('code')
-    print("Answer: (commands only)")
+
     code_blocks = [code.text.replace('\\n', '') for code in code_blocks if len(code.text.split())!=1]
-    for code in code_blocks:
-        print(code)
-    if source_verified:
+    answer = '\n'.join(code_blocks) #concatenated list of commands (code) as the answer
+
+    if source_verified: #getting answer from verified answers (only)
         answer_id = verified_question.get('id')
         answer_id = findall(r'\d+', answer_id)[0]
-        url = f"https://{platform}/a/{answer_id}"
-    print(f"Url: {url}")
-        
+        url = f"https://{platform}/a/{answer_id}" #answer share link
 
-platform_to_tag = {
+    final_answer = None #defaults to None
+
+    #answer schema as a dict - to be changed to csv
+    post = {
+        'question': question,
+        'answer': answer,
+        'source_verified': source_verified,
+        'manual_verified': manual_verified,
+        'url': url,
+        'final_answer': final_answer
+    }
+    return post
+
+#Parameters
+
+platform_to_tag = { #tags and platforms to consider
     "askubuntu": [
         "mysql", "command-line", "apt"
     ],
@@ -54,12 +62,16 @@ platform_to_tag = {
         "aiohttp", "python", "django"
     ]
 }
+#test
+platform_to_tag = {
+    "askubuntu": ["apt"]
+}
 
 PAGE_MAX = 3 #number of pages to consider
-tag_urls = {}
 
 
-def main():
+def collect_urls():
+    tag_urls = {}
     for platform in platform_to_tag:
         tags = platform_to_tag[platform]
         for tag in tags:
@@ -68,7 +80,23 @@ def main():
                 for url in Tag_To_Url(base=platform, tag=tag, page=i):
                     tag_urls[tag].extend(url)
             print(f"Found {len(tag_urls[tag])} urls for tag {tag} in {platform} searching {PAGE_MAX} pages")
+    return tag_urls
 
 
-Link_To_Data(['https://askubuntu.com/questions/17823/how-to-list-all-installed-packages'])
+def data_from_url(tag_urls: dict):
+    dataset = []
+    for tag in tag_urls:
+        urls = tag_urls[tag]
+        for url in urls:
+            dataset.append(Url_To_Data(url=url))
+        print(f"Collected data from {len(urls)} urls with tag {tag}")
+    return dataset
+
+
+if __name__ == '__main__':
+    urls = collect_urls()
+    dataset = data_from_url(tag_urls=urls)
+
+
+
 

--- a/dataset/datasetGen.py
+++ b/dataset/datasetGen.py
@@ -3,93 +3,113 @@ from re import findall, search
 from bs4 import BeautifulSoup
 
 
-def Tag_To_Url(base: str, tag: str, page: int):
-    base = f'https://{base}.com/'
-    URL = '{base}questions/tagged/{tag}?tab=votes&page={i}&pagesize=15'
-    with request.urlopen(URL.format(base=base, tag=tag, i=page)) as response:
-        content = response.read()
-    tag_url = findall(r'<h3><a href="(.*?)" class', str(content))[1:]
-    tag_url = [f'{base}{link}' for link in tag_url]
-    # return list of urls for that tag
-    yield tag_url
+class DataSetGen:
+    def __init__(self):
+        self.PAGE_MAX = 3
+        self.platform_to_tag = {  # tags and platforms to consider
+            "askubuntu": [
+                "mysql", "command-line", "apt"
+            ],
+            "stackoverflow": [
+                "aiohttp", "python", "django"
+            ]
+        }
+        self.URL = '{base}questions/tagged/{tag}?tab=votes&page={i}&pagesize=15'
+        self.tag_urls = {}
+        self.soup = None
+        self.platform = None
 
+    def tag_to_url(self, base: str, tag: str, page: int):
+        base = f'https://{base}.com/'
+        with request.urlopen(self.URL.format(base=base, tag=tag, i=page)) as response:
+            content = response.read()
+        tag_url = findall(r'<h3><a href="(.*?)" class', str(content))[1:]
+        tag_url = [f'{base}{link}' for link in tag_url]
+        # return list of urls for that tag
+        yield tag_url
 
-def Url_To_Data(url: str):
-    platform = search('https?://([A-Za-z_0-9.-]+).com*', url).group(1)
-    with request.urlopen(url) as response:
-        content = response.read()
-    soup = BeautifulSoup(str(content), 'html.parser')
-    question = soup.find("a", {"class": "question-hyperlink"}).text
+    def collect_urls(self):
+        for platform in self.platform_to_tag:
+            tags = self.platform_to_tag[platform]
+            for tag in tags:
+                self.tag_urls[tag] = []
+                for i in range(1, self.PAGE_MAX + 1):  # PAGE_MAX number of list of urls per iteration
+                    for url in self.tag_to_url(base=platform, tag=tag, page=i):
+                        self.tag_urls[tag].extend(url)
+                print(
+                    f"Found {len(self.tag_urls[tag])} urls for tag {tag} in {platform} searching {self.PAGE_MAX} pages")
+        return self.tag_urls
 
-    source_verified = False
-    verified_question = soup.find("div", {"class": "answer accepted-answer"})
-    if verified_question:
-        source_verified = True  # is an accepted answer
+    def url_to_data(self, url: str):
+        self.platform = search(r'https?://([A-Za-z_0-9.-]+).com*', url).group(1)
+        with request.urlopen(url) as response:
+            content = response.read()
 
-    manual_verified = False
+        self.soup = BeautifulSoup(str(content), 'html.parser')
 
-    answer = soup.find("div", {"class": "answercell post-layout--right"})
-    code_blocks = answer.find_all('code')
+        question = self.get_question()
+        source_verified = self.is_verified()
+        manual_verified = False
+        if not source_verified:  # skip over ones without accepted answers
+            return None
+        answer = self.get_answer()
+        final_answer = None
 
-    code_blocks = [code.text.replace('\\n', '') for code in code_blocks if len(code.text.split()) != 1]
-    answer = '\n'.join(code_blocks)  # concatenated list of commands (code) as the answer
+        # answer schema as a dict - to be changed to csv
+        post = {
+            'question': question,
+            'answer': answer,
+            'source_verified': source_verified,
+            'manual_verified': manual_verified,
+            'url': url,
+            'final_answer': final_answer
+        }
+        return post
 
-    if source_verified:  # getting answer from verified answers (only)
-        answer_id = verified_question.get('id')
-        answer_id = findall(r'\d+', answer_id)[0]
-        url = f"https://{platform}/a/{answer_id}"  # answer share link
+    def get_question(self):
+        question = self.soup.find("a", {"class": "question-hyperlink"}).text
+        return question
 
-    final_answer = None  # defaults to None
+    def is_verified(self):
+        verified = self.soup.find("div", {"class": "answer accepted-answer"})
+        url = None
+        try:
+            answer_id = verified.get('id')
+            answer_id = findall(r'\d+', answer_id)[0]
+            url = f"https://{self.platform}/a/{answer_id}"  # answer share link
+            verified = True
 
-    # answer schema as a dict - to be changed to csv
-    post = {
-        'question': question,
-        'answer': answer,
-        'source_verified': source_verified,
-        'manual_verified': manual_verified,
-        'url': url,
-        'final_answer': final_answer
-    }
-    return post
+        except Exception:
+            verified = False
 
+        return verified, url
 
-# Parameters
+    def get_answer(self):
+        answer = self.soup.find("div", {"class": "answercell post-layout--right"})
+        code_blocks = answer.find_all('code')
+        code_blocks = [code.text.replace('\\n', '') for code in code_blocks if len(code.text.split()) != 1]
+        answer = '\n'.join(code_blocks)  # concatenated list of commands (code) as the answer
+        return answer
 
-platform_to_tag = {  # tags and platforms to consider
-    "askubuntu": [
-        "mysql", "command-line", "apt"
-    ],
-    "stackoverflow": [
-        "aiohttp", "python", "django"
-    ]
-}
-
-PAGE_MAX = 3  # number of pages to consider
-
-
-def collect_urls():
-    tag_urls = {}
-    for platform in platform_to_tag:
-        tags = platform_to_tag[platform]
-        for tag in tags:
-            tag_urls[tag] = []
-            for i in range(1, PAGE_MAX + 1):  # PAGE_MAX number of list of urls per iteration
-                for url in Tag_To_Url(base=platform, tag=tag, page=i):
-                    tag_urls[tag].extend(url)
-            print(f"Found {len(tag_urls[tag])} urls for tag {tag} in {platform} searching {PAGE_MAX} pages")
-    return tag_urls
-
-
-def data_from_url(tag_urls: dict):
-    _dataset = []
-    for tag in tag_urls:
-        _urls = tag_urls[tag]
-        for url in _urls:
-            _dataset.append(Url_To_Data(url=url))
-        print(f"Collected data from {len(urls)} urls with tag {tag}")
-    return _dataset
+    def data_from_url(self):
+        _dataset = []
+        for tag in self.tag_urls:
+            _urls = self.tag_urls[tag]
+            for url in _urls:
+                _dataset.append(self.url_to_data(url=url))
+            print(f"Collected data from {len(_urls)} urls with tag {tag}")
+        return _dataset
 
 
 if __name__ == '__main__':
-    urls = collect_urls()
-    dataset = data_from_url(tag_urls=urls)
+    data_gen = DataSetGen()
+    data_gen.PAGE_MAX = 1
+    data_gen.platform_to_tag = {
+        "askubuntu": [
+            "apt"
+        ]
+    }
+    data_gen.collect_urls()
+    data_set = data_gen.data_from_url()
+    print(len(data_set))
+

--- a/dataset/datasetGen.py
+++ b/dataset/datasetGen.py
@@ -10,7 +10,7 @@ def Tag_To_Url(base: str, tag: str, page: int):
         content = response.read()
     tag_url = findall(r'<h3><a href="(.*?)" class', str(content))[1:]
     tag_url = [f'{base}{link}' for link in tag_url]
-    #return list of urls for that tag
+    # return list of urls for that tag
     yield tag_url
 
 
@@ -24,24 +24,24 @@ def Url_To_Data(url: str):
     source_verified = False
     verified_question = soup.find("div", {"class": "answer accepted-answer"})
     if verified_question:
-        source_verified = True #is an accepted answer
+        source_verified = True  # is an accepted answer
 
     manual_verified = False
 
     answer = soup.find("div", {"class": "answercell post-layout--right"})
     code_blocks = answer.find_all('code')
 
-    code_blocks = [code.text.replace('\\n', '') for code in code_blocks if len(code.text.split())!=1]
-    answer = '\n'.join(code_blocks) #concatenated list of commands (code) as the answer
+    code_blocks = [code.text.replace('\\n', '') for code in code_blocks if len(code.text.split()) != 1]
+    answer = '\n'.join(code_blocks)  # concatenated list of commands (code) as the answer
 
-    if source_verified: #getting answer from verified answers (only)
+    if source_verified:  # getting answer from verified answers (only)
         answer_id = verified_question.get('id')
         answer_id = findall(r'\d+', answer_id)[0]
-        url = f"https://{platform}/a/{answer_id}" #answer share link
+        url = f"https://{platform}/a/{answer_id}"  # answer share link
 
-    final_answer = None #defaults to None
+    final_answer = None  # defaults to None
 
-    #answer schema as a dict - to be changed to csv
+    # answer schema as a dict - to be changed to csv
     post = {
         'question': question,
         'answer': answer,
@@ -52,9 +52,10 @@ def Url_To_Data(url: str):
     }
     return post
 
-#Parameters
 
-platform_to_tag = { #tags and platforms to consider
+# Parameters
+
+platform_to_tag = {  # tags and platforms to consider
     "askubuntu": [
         "mysql", "command-line", "apt"
     ],
@@ -62,12 +63,8 @@ platform_to_tag = { #tags and platforms to consider
         "aiohttp", "python", "django"
     ]
 }
-#test
-platform_to_tag = {
-    "askubuntu": ["apt"]
-}
 
-PAGE_MAX = 3 #number of pages to consider
+PAGE_MAX = 3  # number of pages to consider
 
 
 def collect_urls():
@@ -76,7 +73,7 @@ def collect_urls():
         tags = platform_to_tag[platform]
         for tag in tags:
             tag_urls[tag] = []
-            for i in range(1, PAGE_MAX+1): #PAGE_MAX number of list of urls per iteration
+            for i in range(1, PAGE_MAX + 1):  # PAGE_MAX number of list of urls per iteration
                 for url in Tag_To_Url(base=platform, tag=tag, page=i):
                     tag_urls[tag].extend(url)
             print(f"Found {len(tag_urls[tag])} urls for tag {tag} in {platform} searching {PAGE_MAX} pages")
@@ -84,19 +81,15 @@ def collect_urls():
 
 
 def data_from_url(tag_urls: dict):
-    dataset = []
+    _dataset = []
     for tag in tag_urls:
-        urls = tag_urls[tag]
-        for url in urls:
-            dataset.append(Url_To_Data(url=url))
+        _urls = tag_urls[tag]
+        for url in _urls:
+            _dataset.append(Url_To_Data(url=url))
         print(f"Collected data from {len(urls)} urls with tag {tag}")
-    return dataset
+    return _dataset
 
 
 if __name__ == '__main__':
     urls = collect_urls()
     dataset = data_from_url(tag_urls=urls)
-
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+BeautifulSoup4


### PR DESCRIPTION
## Change Overview:
Uses `bs4` to scrape requirements mentioned in [issue](https://github.com/Nysa-clan/DeepLI/issues/8)
Current format:
![image](https://user-images.githubusercontent.com/60320192/94926154-f33bd400-04dd-11eb-9b02-d236bd749ca5.png)
`question`, `url` and `source_verified` was acquired relatively easily. `answer` is the combination of commands being mentioned in the accepted answer. Due to the nature of the filter being applied (ranked by votes) only accepted answer is taken as the `answer`. `manual_verified` and `final_answer` defaults to False and None since they need to be verified manually.

## Testing Overview:
Creating a `dict` for each `url` and appending to a `list` is memory intensive and takes a while to finish. 
Can be replaced with writing to csv to remove that overhead.

## Related Issues / PRs:
Further testing will have to be done remotely with larger `PAGE_MAX`.